### PR TITLE
manually implement wp_link_get_state

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -23,7 +23,7 @@ generate = [
 	"Wp.PluginFeatures",
 	"Wp.NodeFeatures",
 	"Wp.Object",
-	"Wp.Device", "Wp.Endpoint", "Wp.Factory", "Wp.Link", "Wp.Port",
+	"Wp.Device", "Wp.Endpoint", "Wp.Factory", "Wp.Port",
 	"Wp.ImplEndpoint",
 	"Wp.FeatureActivationTransition",
 	"Wp.SiEndpoint", "Wp.ImplMetadata",
@@ -156,6 +156,13 @@ status = "generate"
 	[[object.function]]
 	pattern = "(lookup_port|new_ports_filtered_iterator)"
 	ignore = true
+
+[[object]]
+name = "Wp.Link"
+status = "generate"
+	[[object.function]]
+	name = "get_state"
+	manual = true
 
 # enums
 

--- a/Gir.toml
+++ b/Gir.toml
@@ -154,6 +154,9 @@ status = "generate"
 name = "Wp.Node"
 status = "generate"
 	[[object.function]]
+	name = "get_state"
+	manual = true
+	[[object.function]]
 	pattern = "(lookup_port|new_ports_filtered_iterator)"
 	ignore = true
 

--- a/src/auto/link.rs
+++ b/src/auto/link.rs
@@ -12,7 +12,7 @@ use glib::{prelude::*,signal::{connect_raw, SignalHandlerId}};
 use std::{mem};
 #[cfg(any(feature = "v0_4_11", feature = "dox"))]
 #[cfg_attr(feature = "dox", doc(cfg(feature = "v0_4_11")))]
-use std::{boxed::Box as Box_,mem::transmute,ptr};
+use std::{boxed::Box as Box_,mem::transmute};
 
 glib::wrapper! {
     #[doc(alias = "WpLink")]
@@ -42,18 +42,6 @@ impl Link {
             let mut input_port = mem::MaybeUninit::uninit();
             ffi::wp_link_get_linked_object_ids(self.to_glib_none().0, output_node.as_mut_ptr(), output_port.as_mut_ptr(), input_node.as_mut_ptr(), input_port.as_mut_ptr());
             (output_node.assume_init(), output_port.assume_init(), input_node.assume_init(), input_port.assume_init())
-        }
-    }
-
-    #[cfg(any(feature = "v0_4_11", feature = "dox"))]
-    #[cfg_attr(feature = "dox", doc(cfg(feature = "v0_4_11")))]
-    #[doc(alias = "wp_link_get_state")]
-    #[doc(alias = "get_state")]
-    pub fn state(&self) -> (LinkState, glib::GString) {
-        unsafe {
-            let mut error = ptr::null();
-            let ret = from_glib(ffi::wp_link_get_state(self.to_glib_none().0, &mut error));
-            (ret, from_glib_none(error))
         }
     }
 

--- a/src/auto/node.rs
+++ b/src/auto/node.rs
@@ -3,7 +3,7 @@
 
 use crate::{Core,GlobalProxy,Iterator,NodeState,Object,ObjectInterest,PipewireObject,Port,Properties,Proxy};
 use glib::{prelude::*,signal::{connect_raw, SignalHandlerId},translate::*};
-use std::{boxed::Box as Box_,mem,mem::transmute,ptr};
+use std::{boxed::Box as Box_,mem,mem::transmute};
 
 glib::wrapper! {
     #[doc(alias = "WpNode")]
@@ -48,16 +48,6 @@ impl Node {
     pub fn n_ports(&self) -> u32 {
         unsafe {
             ffi::wp_node_get_n_ports(self.to_glib_none().0)
-        }
-    }
-
-    #[doc(alias = "wp_node_get_state")]
-    #[doc(alias = "get_state")]
-    pub fn state(&self) -> (NodeState, glib::GString) {
-        unsafe {
-            let mut error = ptr::null();
-            let ret = from_glib(ffi::wp_node_get_state(self.to_glib_none().0, &mut error));
-            (ret, from_glib_none(error))
         }
     }
 

--- a/src/pw/link.rs
+++ b/src/pw/link.rs
@@ -101,3 +101,13 @@ impl StaticType for LinkFeatures {
 		pw::ProxyFeatures::static_type()
 	}
 }
+
+#[cfg(any(feature = "v0_4_11", feature = "dox"))]
+impl<E> From<Result<LinkState, E>> for LinkState {
+	fn from(res: Result<LinkState, E>) -> Self {
+		match res {
+			Ok(state) => state,
+			Err(_) => LinkState::Error,
+		}
+	}
+}

--- a/src/pw/link.rs
+++ b/src/pw/link.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "v0_4_11", feature = "dox"))]
+use crate::pw::LinkState;
 use crate::{
 	core::Core,
 	prelude::*,
@@ -22,6 +24,34 @@ impl Link {
 
 	pub fn error_is_exists(e: &Error) -> bool {
 		e.message().ends_with(": File exists") // TODO
+	}
+
+	#[cfg(any(feature = "v0_4_11", feature = "dox"))]
+	#[cfg_attr(feature = "dox", doc(cfg(feature = "v0_4_11")))]
+	#[doc(alias = "wp_link_get_state")]
+	#[doc(alias = "get_state")]
+	pub fn state(&self) -> LinkState {
+		unsafe { from_glib(ffi::wp_link_get_state(self.to_glib_none().0, ptr::null_mut())) }
+	}
+
+	#[cfg(any(feature = "v0_4_11", feature = "dox"))]
+	#[cfg_attr(feature = "dox", doc(cfg(feature = "v0_4_11")))]
+	#[doc(alias = "wp_link_get_state")]
+	#[doc(alias = "get_state")]
+	pub fn state_result(&self) -> Result<LinkState, Error> {
+		unsafe {
+			let mut error = ptr::null();
+			match from_glib(ffi::wp_link_get_state(self.to_glib_none().0, &mut error)) {
+				LinkState::Error => {
+					let msg: Option<&glib::GStr> = from_glib_none(error);
+					Err(Error::new(
+						LibraryErrorEnum::OperationFailed,
+						msg.map(|s| s.as_str()).unwrap_or("unspecified link state error"),
+					))
+				},
+				state => Ok(state),
+			}
+		}
 	}
 }
 

--- a/src/pw/node.rs
+++ b/src/pw/node.rs
@@ -112,3 +112,12 @@ impl IntoIterator for Node {
 		self.ports()
 	}
 }
+
+impl<E> From<Result<NodeState, E>> for NodeState {
+	fn from(res: Result<NodeState, E>) -> Self {
+		match res {
+			Ok(state) => state,
+			Err(_) => NodeState::Error,
+		}
+	}
+}

--- a/src/pw/node.rs
+++ b/src/pw/node.rs
@@ -1,10 +1,34 @@
 use crate::{
 	prelude::*,
-	pw::{self, Node, PipewireObject, Port},
+	pw::{self, Node, NodeState, PipewireObject, Port},
 	registry::{Interest, InterestContainer, ObjectInterest},
 };
 
 impl Node {
+	#[doc(alias = "wp_node_get_state")]
+	#[doc(alias = "get_state")]
+	pub fn state(&self) -> NodeState {
+		unsafe { from_glib(ffi::wp_node_get_state(self.to_glib_none().0, ptr::null_mut())) }
+	}
+
+	#[doc(alias = "wp_node_get_state")]
+	#[doc(alias = "get_state")]
+	pub fn state_result(&self) -> Result<NodeState, Error> {
+		unsafe {
+			let mut error = ptr::null();
+			match from_glib(ffi::wp_node_get_state(self.to_glib_none().0, &mut error)) {
+				NodeState::Error => {
+					let msg: Option<&glib::GStr> = from_glib_none(error);
+					Err(Error::new(
+						LibraryErrorEnum::OperationFailed,
+						msg.map(|s| s.as_str()).unwrap_or("unspecified node state error"),
+					))
+				},
+				state => Ok(state),
+			}
+		}
+	}
+
 	#[doc(alias = "wp_node_new_ports_iterator")]
 	pub fn ports(&self) -> ValueIterator<Port> {
 		ValueIterator::with_inner(self.new_ports_iterator().unwrap())


### PR DESCRIPTION
I'm not sure how to tell gir that the error argument should be treated as an error, so...

@Ryuukyu313 does this work for you?

```diff
diff --git a/src/view/graph_view.rs b/src/view/graph_view.rs
index aa089ce..ca9bb2b 100644
--- a/src/view/graph_view.rs
+++ b/src/view/graph_view.rs
@@ -433,8 +433,7 @@ mod imp {
                     link_cr.move_to(from_x, from_y);
 
                     // Use dashed line for inactive links, full line otherwise.
-                    // FIXME: This can use the .state method when https://github.com/arcnmx/wireplumber.rs/issues/6 is fixed
-                    if link.property::<wp::pw::LinkState>("state") == wp::pw::LinkState::Active {
+                    if link.state() == wp::pw::LinkState::Active {
                         link_cr.set_dash(&[], 0.0);
                     } else {
                         link_cr.set_dash(&[10.0, 5.0], 0.0);
```

It does draw solid lines as expected, and the `state_result` api works (but isn't entirely ideal)

fixes #6